### PR TITLE
Link to docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,20 +5,6 @@ python-docs-tx-translations
 .. image:: https://github.com/rffontenelle/python-docs-tx-translations/actions/workflows/ci.yml/badge.svg
    :target: https://github.com/rffontenelle/python-docs-tx-translations/actions/workflows/ci.yml
 
-Scripts and procedures for maintaining Python_ documentation translation infrastructure under python-doc_ organization in Transifex_.
+For information about translating on transifex for both users and maintainers see the Documentation_.
 
-Source strings are updated using continuous integration workflow under *.github/workflows*. Details:
-
-- Run weekly
-- Run for releases in beta, release candidate, stable, bugfixes and security-fixes status; alpha or EOL are excluded;
-- It DOES NOT store translations to be used by the published documentation;
-
-See docs_ directory for more information on this project maintenance.
-
-See Translating_ in Python Developer's Guide for more information.
-
-.. _Python: https://www.python.org
-.. _python-doc: https://app.transifex.com/python-doc/
-.. _Transifex: https://www.transifex.com
-.. _docs: https://github.com/rffontenelle/docspush-transifex/blob/main/docs/
-.. _Translating: https://devguide.python.org/documentation/translating/
+.. _Documentation: https://python-docs-tx-translations.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ python-docs-tx-translations
 .. image:: https://github.com/rffontenelle/python-docs-tx-translations/actions/workflows/ci.yml/badge.svg
    :target: https://github.com/rffontenelle/python-docs-tx-translations/actions/workflows/ci.yml
 
+Scripts and procedures for maintaining Python_ documentation translation infrastructure under python-doc_ organization in Transifex_.
 For information about translating on transifex for both users and maintainers see the Documentation_.
 
 .. _Documentation: https://python-docs-tx-translations.readthedocs.io/
+.. _Python: https://www.python.org
+.. _python-doc: https://app.transifex.com/python-doc/
+.. _Transifex: https://www.transifex.com


### PR DESCRIPTION
All of the readme content is now in the Docs index so there is no need to keep two copies.