### PR TITLE
Add html_title to conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,4 +23,4 @@ exclude_patterns = []
 
 html_theme = 'furo'
 html_static_path = ['_static']
-html_title = 'Python Docs Transifex Automations'
+html_title = 'Python Docs Transifex Automation'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,3 +23,4 @@ exclude_patterns = []
 
 html_theme = 'furo'
 html_static_path = ['_static']
+html_title = 'Python Docs Transifex Automations'


### PR DESCRIPTION
Not sure on what exactly it should be. The current (automatic) one is:

> Python Docs Transifex Automation documentation 

<!-- readthedocs-preview python-docs-transifex-automation start -->
----
📚 Documentation preview 📚: https://python-docs-transifex-automation--127.org.readthedocs.build/en/127/

<!-- readthedocs-preview python-docs-transifex-automation end -->